### PR TITLE
Corrected iSHARE brandname

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ## Introduction
 Welcome to the python ishare package. This package implements helpers for the 
-authentication flow between iShare services. Specifically, the part of the process 
-where a json web token (per ishare specification) is transformed into an access token. 
+authentication flow between iSHARE services. Specifically, the part of the process 
+where a json web token (per iSHARE specification) is transformed into an access token. 
 This access token can then be used to communicate with the rest of a Role's service 
 endpoints.
 
@@ -13,37 +13,37 @@ This package could be relevant for connecting to/from the following
 - Service or Data Provider
 - Service or Data Consumers
 
-For more information on iShare;
-* [The iShare website](https://ishare.eu/nl/)
+For more information on ISHARE;
+* [The ISHARE website](https://ishare.eu/nl/)
 * [The developer documentation](https://dev.ishare.eu/)
-* [The iShare Framework](https://ishareworks.atlassian.net/wiki/spaces/IS/overview)
-* [The iShare Satellite repository](https://github.com/iSHAREScheme/iSHARESatellite)
+* [The ISHARE Framework](https://ishareworks.atlassian.net/wiki/spaces/IS/overview)
+* [The ISHARE Satellite repository](https://github.com/iSHAREScheme/iSHARESatellite)
 
 ## Usage
 
 ### Prerequisites
-For a working connection with, for example, an iShare satellite you need a participant 
+For a working connection with, for example, an iSHARE satellite you need a participant 
 registration. 
 
-- From the registration with an iShare Satellite. 
+- From the registration with an iSHARE Satellite. 
   - (encryption) The registered Certificate's *private* RSA key. This must be kept SECRET!
   - (`x509 header`) The registered Certificate's *public* x509 certificate chain. 
   - (`client_id`) The registered participant's EORI number
   - The registered participant adherence status is "Active".
 - For every participant Service you want to connect to:
   - (`audience`) The target service's EORI number
-  - (decryption) Their public x509 (can be retrieved from an iShare Satellite)
+  - (decryption) Their public x509 (can be retrieved from an iSHARE Satellite)
   - The domain of the service you're connecting to
 
 All of these are required to encrypt and decrypt communication between different the 
-iShare services. For more detailed information refer to the `private key jwt` json web 
+iSHARE services. For more detailed information refer to the `private key jwt` json web 
 token flow [here](https://oauth.net/private-key-jwt/).
 
 ### The three-step methodology
 
-1. Create a json web token per ishare [specification](https://dev.ishare.eu/introduction/jwt.html)).
+1. Create a json web token per iSHARE [specification](https://dev.ishare.eu/introduction/jwt.html)).
 2. Use a client interface to communicate with a role
-3. Use the `IShareSatelliteClient` interface to verify a participant
+3. Use the `ISHARESatelliteClient` interface to verify a participant
 
 #### I. Creating the json web token
 
@@ -95,20 +95,20 @@ for two reasons;
 - It makes it possible to sign the json web token externally using an AWS asymmetric key 
 for example. A great security solution.
 
-#### II. Connecting to an iShare Satellite
+#### II. Connecting to an iSHARE Satellite
 
-To connect to an iShare satellite this package provides an `IShareSatelliteClient` 
+To connect to an iSHARE satellite this package provides an `ISHARESatelliteClient` 
 interface class.
 
 ```python
-from python_ishare import IShareSatelliteClient
+from python_ishare import ISHARESatelliteClient
 
 # From step 1
 YOUR_PARTICIPANT_EORI = "XXX"
 my_token = create_jwt(...)
 public_key = ...
 
-client = IShareSatelliteClient(
+client = ISHARESatelliteClient(
     target_domain="satellite.ishare.com",
     target_public_key=public_key,
     client_eori=YOUR_PARTICIPANT_EORI,
@@ -127,10 +127,10 @@ print(public_capabilities)
 The value of this interface class is that you never needed to worry about access tokens.
 This is handled for you underwater. Tokens are re-used whenever a new request is made. 
 
-#### III. Verifying an iShare participant
+#### III. Verifying an iSHARE participant
 
 Verifying a participant is a key responsibility for a number of roles. The 
-`IShareSatelliteClient` has a method to do this for you. 
+`ISHARESatelliteClient` has a method to do this for you. 
 
 ```python
 # From step 2
@@ -140,7 +140,7 @@ client = IShareSatelliteClient(...)
 # Assuming you have some python web framework there will be a request
 request = ...
 
-# If you're a service provider, you can use this to verify other parties ishare tokens
+# If you're a service provider, you can use this to verify other parties iSHARE tokens
 client.verify_json_web_token(
     audience=YOUR_PARTICIPANT_EORI,
     client_id=request.param["client_id"],

--- a/README.md
+++ b/README.md
@@ -39,6 +39,19 @@ All of these are required to encrypt and decrypt communication between different
 iSHARE services. For more detailed information refer to the `private key jwt` json web 
 token flow [here](https://oauth.net/private-key-jwt/).
 
+### Installation
+Install this package using `pip`;
+
+```shell
+pip install python-ishare
+```
+
+or using poetry;
+
+```shell
+poetry add python-ishare
+```
+
 ### The three-step methodology
 
 1. Create a json web token per iSHARE [specification](https://dev.ishare.eu/introduction/jwt.html)).

--- a/src/python_ishare/__init__.py
+++ b/src/python_ishare/__init__.py
@@ -2,7 +2,7 @@
 import logging
 
 from python_ishare.authentication import create_jwt, decode_jwt, x5c_b64_to_certificate
-from python_ishare.clients import CommonBaseClient, IShareSatelliteClient
+from python_ishare.clients import CommonBaseClient, ISHARESatelliteClient
 from python_ishare.verification import validate_client_assertion
 
 logging.getLogger(__name__).addHandler(logging.NullHandler())

--- a/src/python_ishare/authentication.py
+++ b/src/python_ishare/authentication.py
@@ -11,7 +11,7 @@ from cryptography.hazmat.primitives.serialization import Encoding
 from cryptography.x509 import Certificate, load_der_x509_certificate
 from typing_extensions import NotRequired
 
-from python_ishare.exceptions import IShareInvalidTokenX5C
+from python_ishare.exceptions import ISHAREInvalidTokenX5C
 
 ENCRYPTION_ALGORITHM = "RS256"
 
@@ -56,7 +56,7 @@ def get_b64_x5c_fingerprints(json_web_token: str) -> list[CertificateInfo]:
     x5c = headers.get("x5c")
 
     if not isinstance(x5c, list):
-        raise IShareInvalidTokenX5C("Extracted x5c header is not a list.")
+        raise ISHAREInvalidTokenX5C("Extracted x5c header is not a list.")
 
     _hash = hashes.SHA256()
     _finger_prints: list[CertificateInfo] = []
@@ -80,10 +80,10 @@ def create_jwt(
     **kwargs: dict[str, Union[json.JSONEncoder, bool]]
 ) -> str:
     """
-    Create a valid JWT for iShare specific use. As per the "private_key_jwt"
+    Create a valid JWT for iSHARE specific use. As per the "private_key_jwt"
     methodology in openid connect.
 
-    Note: iShare spec dictates a lifetime of 30 seconds.
+    Note: iSHARE spec dictates a lifetime of 30 seconds.
 
     https://openid.net/specs/openid-connect-core-1_0.html
 
@@ -93,7 +93,7 @@ def create_jwt(
         encrypt the payload.
     :param x5c_certificate_chain: An array of the complete certificate chain that should
         be used to validate the JWT signature. Up until the issuing CA from the
-        trust_list from the relevant iShare Satellite.
+        trust_list from the relevant iSHARE Satellite.
     """
     headers = {
         "alg": ENCRYPTION_ALGORITHM,
@@ -126,14 +126,14 @@ def decode_jwt(
     **kwargs: Any
 ) -> Any:
     """
-    Raises specific exception if IShare JWT is not valid.
+    Raises specific exception if iSHARE JWT is not valid.
 
     :param json_web_token:
     :param public_x509_cert:
-        The public X509 certificate uploaded to an iShare Satellite.
+        The public X509 certificate uploaded to an iSHARE Satellite.
     :param audience: eori of the party receiving the json web token
     :return: they payload of the decoded json_web_token.
-    :raises IShareAuthenticationException: if JWT token not valid
+    :raises ISHAREAuthenticationException: if JWT token not valid
     """
     return jwt.decode(
         jwt=json_web_token,

--- a/src/python_ishare/clients.py
+++ b/src/python_ishare/clients.py
@@ -7,8 +7,8 @@ from cryptography.x509 import Certificate
 
 from python_ishare.authentication import decode_jwt, get_b64_x5c_fingerprints
 from python_ishare.exceptions import (
-    IShareInvalidCertificateIssuer,
-    ISharePartyStatusInvalid,
+    ISHAREInvalidCertificateIssuer,
+    ISHAREPartyStatusInvalid,
 )
 from python_ishare.verification import validate_client_assertion
 
@@ -29,7 +29,7 @@ class CommonBaseClient:
     """
     Standalone base client that can be extended for role specific methods.
 
-    - Implements the common auth flow for all iShare participants / roles.
+    - Implements the common auth flow for all iSHARE participants / roles.
     - Implements common api methods
     - Can be extended for different access_token/jwt flow.
 
@@ -57,9 +57,9 @@ class CommonBaseClient:
         """
         :param target_domain: Domain part of the target service, including scheme
         :param target_public_key: Public key to verify the received json web tokens
-        :param client_eori: ishare participant eori of the client
+        :param client_eori: iSHARE participant eori of the client
         :param json_web_token:
-            - type str: pre-made jwt for ishare (see authentication.create_jwt)
+            - type str: pre-made jwt for iSHARE (see authentication.create_jwt)
             - type Callable: a function/class that returns a jwt on demand
         :param timeout: used to stop the web requests to avoid hanging requests
         :param extra: If methods below are overriden this can be used to pass arguments.
@@ -191,9 +191,9 @@ class CommonBaseClient:
         )
 
 
-class IShareSatelliteClient(CommonBaseClient):
+class ISHARESatelliteClient(CommonBaseClient):
     """
-    Responsible for communicating with an iShare Satellite/Scheme Owner.
+    Responsible for communicating with an iSHARE Satellite/Scheme Owner.
     """
 
     def get_trusted_list(self) -> Any:  # pragma: no cover
@@ -238,7 +238,7 @@ class IShareSatelliteClient(CommonBaseClient):
         parties_count = parties_info.get("count", 0)
 
         if not parties_info or parties_count != 1:
-            raise ISharePartyStatusInvalid(
+            raise ISHAREPartyStatusInvalid(
                 f"Invalid result, received {parties_count} parties."
             )
 
@@ -246,17 +246,17 @@ class IShareSatelliteClient(CommonBaseClient):
         only_party = parties_data[0]
 
         if only_party["party_id"] != party_eori:
-            raise ISharePartyStatusInvalid("Invalid party returned.")
+            raise ISHAREPartyStatusInvalid("Invalid party returned.")
 
         adherence = only_party.get("adherence", {})
         if not adherence or adherence["status"] != "Active":
-            raise ISharePartyStatusInvalid("Inactive party returned.")
+            raise ISHAREPartyStatusInvalid("Inactive party returned.")
 
         return result
 
     def verify_ca_certificate(self, json_web_token: str) -> None:
         """
-        Verify whether the given certificate is signed by an CA trusted by iShare.
+        Verify whether the given certificate is signed by an CA trusted by iSHARE.
         :param json_web_token:
         :return:
         """
@@ -271,7 +271,7 @@ class IShareSatelliteClient(CommonBaseClient):
             ):
                 return
         else:
-            raise IShareInvalidCertificateIssuer("No trusted CA found.")
+            raise ISHAREInvalidCertificateIssuer("No trusted CA found.")
 
     def verify_json_web_token(
         self,
@@ -285,13 +285,13 @@ class IShareSatelliteClient(CommonBaseClient):
         ],
     ) -> None:
         """
-        :param client_id: iShare identifier of the Service Consumer.
-        :param client_assertion: the json web token as per iShare specification.
-        :param audience: ishare participant eori of the target service
+        :param client_id: iSHARE identifier of the Service Consumer.
+        :param client_assertion: the json web token as per iSHARE specification.
+        :param audience: iSHARE participant eori of the target service
         :param grant_type:
         :param scope:
         :param client_assertion_type:
-        :raises IShareAuthenticationException: and all it's inheriting classes
+        :raises ISHAREAuthenticationException: and all it's inheriting classes
         :return:
         """
         # TODO: Method flow needs to check the revocation list
@@ -309,7 +309,7 @@ class IShareSatelliteClient(CommonBaseClient):
 
 
 class IShareAuthorizationRegistryClient(CommonBaseClient):
-    """Responsible for communicating with an iShare Authorization Registry."""
+    """Responsible for communicating with an iSHARE Authorization Registry."""
 
     def request_delegation(self, use_token: bool) -> Any:  # pragma: no cover
         """

--- a/src/python_ishare/exceptions.py
+++ b/src/python_ishare/exceptions.py
@@ -1,4 +1,4 @@
-class IShareAuthenticationException(Exception):
+class ISHAREAuthenticationException(Exception):
     """
     Base class exception to be able to catch *all* other types of sub exception raised
     by this package.
@@ -7,77 +7,77 @@ class IShareAuthenticationException(Exception):
     pass
 
 
-class IShareInvalidGrantType(IShareAuthenticationException):
+class ISHAREInvalidGrantType(ISHAREAuthenticationException):
     pass
 
 
-class IShareInvalidScope(IShareAuthenticationException):
+class ISHAREInvalidScope(ISHAREAuthenticationException):
     pass
 
 
-class IShareInvalidAudience(IShareAuthenticationException):
+class ISHAREInvalidAudience(ISHAREAuthenticationException):
     pass
 
 
-class IShareInvalidClientId(IShareAuthenticationException):
+class ISHAREInvalidClientId(ISHAREAuthenticationException):
     pass
 
 
-class IShareInvalidClientAssertionType(IShareAuthenticationException):
+class ISHAREInvalidClientAssertionType(ISHAREAuthenticationException):
     pass
 
 
-class IShareInvalidToken(IShareAuthenticationException):
+class ISHAREInvalidToken(ISHAREAuthenticationException):
     pass
 
 
-class IShareInvalidTokenAlgorithm(IShareInvalidToken):
+class ISHAREInvalidTokenAlgorithm(ISHAREInvalidToken):
     pass
 
 
-class IShareInvalidTokenType(IShareInvalidToken):
+class ISHAREInvalidTokenType(ISHAREInvalidToken):
     pass
 
 
-class IShareInvalidTokenX5C(IShareInvalidToken):
+class ISHAREInvalidTokenX5C(ISHAREInvalidToken):
     pass
 
 
-class IShareInvalidTokenIssuerOrSubscriber(IShareInvalidToken):
+class ISHAREInvalidTokenIssuerOrSubscriber(ISHAREInvalidToken):
     pass
 
 
-class IShareInvalidTokenJTI(IShareInvalidToken):
+class ISHAREInvalidTokenJTI(ISHAREInvalidToken):
     pass
 
 
-class IShareTokenExpirationInvalid(IShareInvalidToken):
+class ISHARETokenExpirationInvalid(ISHAREInvalidToken):
     pass
 
 
-class IShareTokenExpired(IShareInvalidToken):
+class ISHARETokenExpired(ISHAREInvalidToken):
     pass
 
 
-class IShareTokenNotValidYet(IShareInvalidToken):
+class ISHARETokenNotValidYet(ISHAREInvalidToken):
     pass
 
 
-class IShareInvalidTokenSigner(IShareInvalidToken):
+class ISHAREInvalidTokenSigner(ISHAREInvalidToken):
     pass
 
 
-class IShareInvalidCertificate(IShareAuthenticationException):
+class ISHAREInvalidCertificate(ISHAREAuthenticationException):
     pass
 
 
-class IShareCertificateExpired(IShareInvalidCertificate):
+class ISHARECertificateExpired(ISHAREInvalidCertificate):
     pass
 
 
-class IShareInvalidCertificateIssuer(IShareInvalidCertificate):
+class ISHAREInvalidCertificateIssuer(ISHAREInvalidCertificate):
     pass
 
 
-class ISharePartyStatusInvalid(IShareAuthenticationException):
+class ISHAREPartyStatusInvalid(ISHAREAuthenticationException):
     pass

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -9,7 +9,7 @@ from cryptography.x509 import (
 )
 
 from python_ishare.authentication import create_jwt
-from python_ishare.clients import CommonBaseClient, IShareSatelliteClient
+from python_ishare.clients import CommonBaseClient, ISHARESatelliteClient
 
 PB_CLIENT_EORI = "EU.EORI.PBADAPTER"
 
@@ -144,6 +144,6 @@ def integrated_common_auth_client(integration_client_settings) -> CommonBaseClie
 @pytest.fixture()
 def integrated_ishare_satellite_client(
     integration_client_settings,
-) -> IShareSatelliteClient:
+) -> ISHARESatelliteClient:
     """IShareSatelliteClient with integration configuration."""
-    return IShareSatelliteClient(**integration_client_settings)
+    return ISHARESatelliteClient(**integration_client_settings)

--- a/tests/integration/test_satellite.py
+++ b/tests/integration/test_satellite.py
@@ -1,8 +1,8 @@
 import pytest
 
 from python_ishare.exceptions import (
-    IShareInvalidCertificateIssuer,
-    ISharePartyStatusInvalid,
+    ISHAREInvalidCertificateIssuer,
+    ISHAREPartyStatusInvalid,
 )
 
 
@@ -43,7 +43,7 @@ def test_verify_certificate(integrated_ishare_satellite_client, pb_jwt_for_satel
         integrated_ishare_satellite_client.verify_ca_certificate(
             json_web_token=pb_jwt_for_satellite
         )
-    except IShareInvalidCertificateIssuer:
+    except ISHAREInvalidCertificateIssuer:
         pytest.fail(
             "This should be a valid CA check. If this fails the certificate is not "
             "signed by a correct CA *or* the CA was removed from the trusted_list."
@@ -52,7 +52,7 @@ def test_verify_certificate(integrated_ishare_satellite_client, pb_jwt_for_satel
 
 def test_verify_invalid_certificate(integrated_ishare_satellite_client, pb_jwt_invalid):
     """Test whether we can verify our own certificate using the satellite."""
-    with pytest.raises(IShareInvalidCertificateIssuer):
+    with pytest.raises(ISHAREInvalidCertificateIssuer):
         integrated_ishare_satellite_client.verify_ca_certificate(
             json_web_token=pb_jwt_invalid
         )

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -6,7 +6,7 @@ from cryptography.hazmat.primitives.asymmetric.rsa import RSAPrivateKey
 from cryptography.x509 import Certificate
 
 from python_ishare.authentication import create_jwt
-from python_ishare.clients import CommonBaseClient, IShareSatelliteClient
+from python_ishare.clients import CommonBaseClient, ISHARESatelliteClient
 
 
 @pytest.fixture(scope="session")
@@ -80,9 +80,9 @@ def common_auth_client(test_client_arguments) -> CommonBaseClient:
 
 
 @pytest.fixture()
-def satellite_client(test_client_arguments) -> IShareSatelliteClient:
+def satellite_client(test_client_arguments) -> ISHARESatelliteClient:
     """IShareSatelliteClient with test configuration."""
-    return IShareSatelliteClient(**test_client_arguments)
+    return ISHARESatelliteClient(**test_client_arguments)
 
 
 @pytest.fixture(scope="session")

--- a/tests/unit/test_verification.py
+++ b/tests/unit/test_verification.py
@@ -5,18 +5,18 @@ import pytest
 
 from python_ishare.authentication import create_jwt
 from python_ishare.exceptions import (
-    IShareInvalidAudience,
-    IShareInvalidClientAssertionType,
-    IShareInvalidClientId,
-    IShareInvalidGrantType,
-    IShareInvalidScope,
-    IShareInvalidTokenAlgorithm,
-    IShareInvalidTokenIssuerOrSubscriber,
-    IShareInvalidTokenJTI,
-    IShareInvalidTokenType,
-    IShareTokenExpirationInvalid,
-    IShareTokenExpired,
-    IShareTokenNotValidYet,
+    ISHAREInvalidAudience,
+    ISHAREInvalidClientAssertionType,
+    ISHAREInvalidClientId,
+    ISHAREInvalidGrantType,
+    ISHAREInvalidScope,
+    ISHAREInvalidTokenAlgorithm,
+    ISHAREInvalidTokenIssuerOrSubscriber,
+    ISHAREInvalidTokenJTI,
+    ISHAREInvalidTokenType,
+    ISHARETokenExpirationInvalid,
+    ISHARETokenExpired,
+    ISHARETokenNotValidYet,
 )
 from python_ishare.verification import validate_client_assertion
 
@@ -24,7 +24,7 @@ CLIENT_ASSERTION_TYPE = "urn:ietf:params:oauth:client-assertion-type:jwt-bearer"
 
 
 def test_invalid_grant_type():
-    with pytest.raises(IShareInvalidGrantType):
+    with pytest.raises(ISHAREInvalidGrantType):
         validate_client_assertion(
             grant_type="",
             client_id="",
@@ -36,7 +36,7 @@ def test_invalid_grant_type():
 
 
 def test_invalid_scope():
-    with pytest.raises(IShareInvalidScope):
+    with pytest.raises(ISHAREInvalidScope):
         validate_client_assertion(
             grant_type="client_credentials",
             client_assertion_type="",
@@ -57,7 +57,7 @@ def test_audience_mismatch(satellite_key_and_certs):
         x5c_certificate_chain=public_cert_chain,
     )
 
-    with pytest.raises(IShareInvalidAudience):
+    with pytest.raises(ISHAREInvalidAudience):
         validate_client_assertion(
             grant_type="client_credentials",
             scope="iSHARE",
@@ -78,7 +78,7 @@ def test_no_client_id(satellite_key_and_certs):
         x5c_certificate_chain=public_cert_chain,
     )
 
-    with pytest.raises(IShareInvalidClientId):
+    with pytest.raises(ISHAREInvalidClientId):
         validate_client_assertion(
             grant_type="client_credentials",
             scope="iSHARE",
@@ -98,7 +98,7 @@ def test_invalid_client_id(satellite_key_and_certs):
         x5c_certificate_chain=public_cert_chain,
     )
 
-    with pytest.raises(IShareInvalidClientId):
+    with pytest.raises(ISHAREInvalidClientId):
         validate_client_assertion(
             grant_type="client_credentials",
             scope="iSHARE",
@@ -110,7 +110,7 @@ def test_invalid_client_id(satellite_key_and_certs):
 
 
 def test_invalid_client_assertion_type():
-    with pytest.raises(IShareInvalidClientAssertionType):
+    with pytest.raises(ISHAREInvalidClientAssertionType):
         validate_client_assertion(
             grant_type="client_credentials",
             scope="iSHARE",
@@ -129,7 +129,7 @@ def test_invalid_algorithm(satellite_key_and_certs):
         payload={}, key=rsa_key, headers=token_headers, algorithm="RS384"
     )
 
-    with pytest.raises(IShareInvalidTokenAlgorithm):
+    with pytest.raises(ISHAREInvalidTokenAlgorithm):
         validate_client_assertion(
             grant_type="client_credentials",
             scope="iSHARE",
@@ -148,7 +148,7 @@ def test_invalid_token_type(satellite_key_and_certs):
         payload={}, key=rsa_key, headers=token_headers, algorithm="RS256"
     )
 
-    with pytest.raises(IShareInvalidTokenType):
+    with pytest.raises(ISHAREInvalidTokenType):
         validate_client_assertion(
             grant_type="client_credentials",
             scope="iSHARE",
@@ -173,7 +173,7 @@ def test_invalid_issuer_or_subscriber(satellite_client, satellite_key_and_certs)
         x5c_certificate_chain=public_cert_chain,
     )
 
-    with pytest.raises(IShareInvalidTokenIssuerOrSubscriber):
+    with pytest.raises(ISHAREInvalidTokenIssuerOrSubscriber):
         validate_client_assertion(
             grant_type="client_credentials",
             scope="iSHARE",
@@ -200,7 +200,7 @@ def test_invalid_jti(satellite_key_and_certs):
         algorithm="RS256",
     )
 
-    with pytest.raises(IShareInvalidTokenJTI):
+    with pytest.raises(ISHAREInvalidTokenJTI):
         validate_client_assertion(
             grant_type="client_credentials",
             scope="iSHARE",
@@ -230,7 +230,7 @@ def test_invalid_expiration(satellite_key_and_certs):
         algorithm="RS256",
     )
 
-    with pytest.raises(IShareTokenExpirationInvalid):
+    with pytest.raises(ISHARETokenExpirationInvalid):
         validate_client_assertion(
             grant_type="client_credentials",
             scope="iSHARE",
@@ -260,7 +260,7 @@ def test_token_not_valid_yet(satellite_key_and_certs):
         algorithm="RS256",
     )
 
-    with pytest.raises(IShareTokenNotValidYet):
+    with pytest.raises(ISHARETokenNotValidYet):
         validate_client_assertion(
             grant_type="client_credentials",
             scope="iSHARE",
@@ -289,7 +289,7 @@ def test_token_expired(satellite_key_and_certs):
         algorithm="RS256",
     )
 
-    with pytest.raises(IShareTokenExpired):
+    with pytest.raises(ISHARETokenExpired):
         validate_client_assertion(
             grant_type="client_credentials",
             scope="iSHARE",


### PR DESCRIPTION
PR to correct the iSHARE branding. E.g. not iShare. 

Code instances we have to respect the CamelCase convention so `ISHARESomeClass` approach is chosen. 